### PR TITLE
fixes #94

### DIFF
--- a/cifsdk/client.py
+++ b/cifsdk/client.py
@@ -11,6 +11,7 @@ from cifsdk.feed import factory as feed_factory
 
 from argparse import ArgumentParser
 from argparse import RawDescriptionHelpFormatter
+from signal import signal, SIGPIPE, SIG_DFL
 import textwrap
 import copy
 import arrow
@@ -425,6 +426,7 @@ def main():
                     with open(args.filename, 'w') as F:
                         F.write(str(ret))
                 else:
+                    signal(SIGPIPE, SIG_DFL)
                     print(ret)
             else:
                 logger.info("no results found...")


### PR DESCRIPTION
appears to work with all (working) output plugins

```
$ cif --feed --otype fqdn --provider spamhaus.org --format csv | head -n 2
"tlp","group","lasttime","reporttime","observable","otype","cc","asn","asn_desc","confidence","description","tags","rdata","rtype","provider","altid","altid_tlp"
"green","everyone","2016-04-14T18:45:17Z","2016-04-14T18:45:17Z","picofile.com","fqdn","","","","95","spammed domain","suspicious","picofile.com","","spamhaus.org","http://www.spamhaus.org/query/dbl?domain=picofile.com","green"
```