### PR TITLE
right idea but doesn't work for all cases

### DIFF
--- a/cifsdk/client.py
+++ b/cifsdk/client.py
@@ -257,7 +257,10 @@ def main():
     p.add_argument('-d', '--debug', dest='debug', action="store_true", help="logging level: DEBUG")
     p.add_argument('-V', '--version', action='version', version=VERSION)
     p.add_argument('--no-verify-ssl', action="store_true", default=False)
-    p.add_argument('-R', '--remote',  help="remote api location")
+    if os.getenv('CIF_REMOTE_ADDR') != None:
+        p.add_argument('-R', '--remote', help="remote api location", default=REMOTE_ADDR)
+    else:
+        p.add_argument('-R', '--remote', help="remote api location")
     p.add_argument('-T', '--token', help="specify token",  default=TOKEN)
     p.add_argument('--timeout',  help='connection timeout [default: %(default)s]', default="300")
     p.add_argument('-C', '--config',  help="configuration file [default: %(default)s]",

--- a/cifsdk/utils.py
+++ b/cifsdk/utils.py
@@ -18,6 +18,8 @@ def read_config(args):
         for k in config:
             if not options.get(k):
                 options[k] = config[k]
+    elif os.environ.get('CIF_NO_CONFIG_FILE') == '1':
+        return options
     else:
         print("Unable to read {} config file".format(args.config))
         raise SystemExit


### PR DESCRIPTION
this allows cif to have all settings be env vars (for those that have env var options), and not have a cif.yml file. Still some issues around the various ways to include remote addr though